### PR TITLE
Work around jQuery OpenSSH install issue on 1.9.2/win32

### DIFF
--- a/recipes/jquery.rb
+++ b/recipes/jquery.rb
@@ -1,5 +1,13 @@
 gem "jquery-rails"
 
 stategies << lambda do
-  generate 'jquery:install --ui' #to enable jQuery UI
+  # Do special things to get around the HTTPS issue with Ruby 1.9.2 on Win32
+  inside('config') do
+    run 'cp environment.rb environment.~'
+    say_status "info", "Overriding OpenSSL to not verify CA chain for jQuery install.", :yellow
+    say_status "info", "    expect warning about already initialized constant VERIFY_PEER", :yellow
+    gsub_file 'environment.rb', '# Load the rails application', "require 'openssl'\nOpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE"
+    generate 'jquery:install --ui'
+    run 'mv environment.~ environment.rb'   # resotre the original file without the hackery
+  end
 end


### PR DESCRIPTION
This is a known issue:
  https://github.com/rails/jquery-ujs/issues/62
  http://support.github.com/discussions/repos/4714-jquery-github-ssl

I have applied a solution that I came up with (based on the info in the above posts) to solve this with templates.  As far as I am aware this should not affect other OSes; however I am not near my mac so I cant not attest to this.  

Even if it did, it shouldn't be to hard to add a branch to only execute this on a win32 platform.
